### PR TITLE
fix(fish): migrate ssme profile selection from aws-vault to SSO

### DIFF
--- a/private_dot_config/private_fish/functions/ssme.fish
+++ b/private_dot_config/private_fish/functions/ssme.fish
@@ -1,0 +1,13 @@
+function ssme
+    argparse 'r/region=' -- $argv
+    
+    if test -n "$_flag_region"
+        set -x AWS_REGION "$_flag_region"
+    end
+        
+    set --local profile (\
+        aws configure list-profiles | peco
+    )
+    set --local id (ave "$profile" aws ec2 describe-instances --filter "Name=instance-state-name,Values=running" --query 'Reservations[].Instances[].{name:Tags[?Key==`Name`].Value | [0], id: InstanceId}' | jq -r '.[] | "\(.id) \(.name)"' | peco | awk '{print $1}')
+    ave "$profile" aws ssm start-session --target "$id"
+end


### PR DESCRIPTION
## 概要

`ssme` の失敗を修正し、dotfiles リポジトリに取り込みました（これまで実機の `~/.config/fish/functions/ssme.fish` にだけ存在し未管理でした）。

## 変更点

- **プロファイル選択を aws-vault から SSO に移行**: `ave` / `avl` / `avep` はすでに `aws configure list-profiles` + SSO に移行済みでしたが、`ssme` だけ `aws-vault list --profiles` のまま残っており失敗していました。兄弟関数に合わせて `aws configure list-profiles` に変更。
- **region フラグ判定の `$` 抜けを修正**: `test -n "_flag_region"` → `test -n "$_flag_region"`。文字列リテラル比較になっていて常に真となり、`-r` 未指定でも空の `AWS_REGION` が export されていました。

## テスト

- `fish --no-execute` による構文チェック OK
- argparse の分岐ロジックを再現確認（`-r` なし → スキップ / `-r <region>` → セット）

https://claude.ai/code/session_0194HDnkBj92W6cKoUnD738d
